### PR TITLE
Promote to prod environment

### DIFF
--- a/components/python-ixfqezjl/overlays/prod/deployment-patch.yaml
+++ b/components/python-ixfqezjl/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-ixfqezjl:github-c5ab25b2f34217f5ebe648df92c7214a4f1dcfe3
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-ixfqezjl:github-c5ab25b2f34217f5ebe648df92c7214a4f1dcfe3